### PR TITLE
Start using a custom singleuser image

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,8 @@ hub:
           def pre_spawn_start(self, user, spawner):
             auth_state = yield user.get_auth_state()
             spawner.auth_state = auth_state
+            spawner._OH_CLIENT_ID = self.client_id
+            spawner._OH_CLIENT_SECRET = self.client_secret
 
       class OHKubeSpawner(KubeSpawner):
           def get_env(self):
@@ -25,22 +27,36 @@ hub:
               oauth_user = self.auth_state['oauth_user']
               env['OH_PROJECT_MEMBER_ID'] = oauth_user['project_member_id']
               env['OH_ACCESS_TOKEN'] = self.auth_state['access_token']
+              env['OH_CLIENT_ID'] = self._OH_CLIENT_ID
+              env['OH_CLIENT_SECRET'] = self._OH_CLIENT_SECRET
+              env['OH_OAUTH2_TOKEN_URL'] = 'https://www.openhumans.org/oauth2/token/'
               return env
       c.JupyterHub.spawner_class = OHKubeSpawner
       c.JupyterHub.authenticator_class = OHAuthenticator
+      c.Authenticator.enable_auth_state = True
 
     extraEnv:
         OAUTH2_AUTHORIZE_URL: https://www.openhumans.org/direct-sharing/projects/oauth2/authorize/
         OAUTH2_TOKEN_URL: https://www.openhumans.org/oauth2/token/
         OAUTH2_USERDATA_URL: https://www.openhumans.org/api/direct-sharing/project/exchange-member/
+        JUPYTERHUB_CRYPT_KEY: 917d71e3604426b4717a91a9dec85148db0cc23b1dbc7ecd671fedc48d0a90d5
 
 auth:
+  type: custom
   state:
     enabled: true
-  type: custom
+    cryptoKey: "917d71e3604426b4717a91a9dec85148db0cc23b1dbc7ecd671fedc48d0a90d5"
   custom:
-    className: 'oauthenticator.generic.GenericOAuthenticator'
+    className: 'OHAuthenticator'
     config:
       oauth_callback_url: "https://notebooks.openhumans.org//hub/oauth_callback"
       token_url: "https://www.openhumans.org/oauth2/token/"
       login_service: "OpenHumans"
+
+singleuser:
+  image:
+    name: betatim/openhumans-singleuser
+    tag: v1
+  memory:
+    limit: 4G
+    guarantee: 1G

--- a/images/user/Dockerfile
+++ b/images/user/Dockerfile
@@ -1,0 +1,9 @@
+FROM jupyter/datascience-notebook:65f1c4bea0b2
+
+# pin jupyterhub to match the Hub version
+# set via `docker build --build-arg ...`
+ARG JUPYTERHUB_VERSION=0.8.1
+RUN pip install --no-cache jupyterhub==$JUPYTERHUB_VERSION
+
+RUN pip install git+https://github.com/OpenHumans/jhoauth-refresh@ba3bd3782a31612abeca8eb13a41b56ec68947df
+RUN jupyter serverextension enable --py jhoauthrefresh --sys-prefix

--- a/images/user/README.md
+++ b/images/user/README.md
@@ -1,0 +1,32 @@
+# OpenHumans Singleuser Image
+
+The contents of this image is what is available to people when they start
+their notebook.
+
+The image has to be pushed to docker hub in order for JupyterHub to be able to
+use it.
+
+
+# Image contents
+
+The image is based on https://hub.docker.com/r/jupyter/datascience-notebook/.
+You can find the source for this image [here](https://github.com/jupyter/docker-stacks/tree/master/datascience-notebook).
+At the very least we have to add jupyterhub and the oauth token refresher to
+this image or any other image we want to use.
+
+The datascience image has python, R and Julia installed with a reasonable set
+of libraries for each.
+
+
+# Updating the image
+
+Open a terminal in this directory and run:
+```
+docker build -t betatim/openhumans-singleuser:vXXX .
+```
+Replacing `vXXX` with the next available tag after checking [dockerhub](https://hub.docker.com/r/betatim/openhumans-singleuser/)
+for tags that are already used.
+
+Now push the image to docker hub: `docker push betatim/openhumans-singleuser:vXXX`.
+
+Update the singleuser image entry in `config.yaml` and run `helm deploy ...`.


### PR DESCRIPTION
This adds a custom image with basic "data-science" libraries (R, Julia and Python + libraries). This starts closing #4.

In addition it adds a memory limit per user pod. We guarantee each user 1GB and limit them to 4GB.