### PR TITLE
Upgrade user base image, add new python packages

### DIFF
--- a/images/user/Dockerfile
+++ b/images/user/Dockerfile
@@ -1,11 +1,16 @@
-FROM jupyter/datascience-notebook:65f1c4bea0b2
+FROM jupyter/datascience-notebook:8a1b90cbcba5
 
 # pin jupyterhub to match the Hub version
 # set via `docker build --build-arg ...`
 ARG JUPYTERHUB_VERSION=0.8.1
 RUN pip install --no-cache jupyterhub==$JUPYTERHUB_VERSION
 
-RUN pip install git+https://github.com/OpenHumans/jhoauth-refresh@3ce0b6f7d42f0416cf056dcb887cfefb62b8b513
+RUN pip install --no-cache git+https://github.com/OpenHumans/jhoauth-refresh@3ce0b6f7d42f0416cf056dcb887cfefb62b8b513
 RUN jupyter serverextension enable --py jhoauthrefresh --sys-prefix
 
 RUN R -e "install.packages(c('stringr', 'tidytext', 'purrr', 'widyr'), repos = 'http://cran.us.r-project.org')"
+
+RUN pip install --no-cache \
+       textblob==0.15.1 \
+       emoji==0.5.0
+RUN python -m textblob.download_corpora

--- a/ohjh/values.yaml
+++ b/ohjh/values.yaml
@@ -58,7 +58,7 @@ jupyterhub:
   singleuser:
     image:
       name: betatim/openhumans-singleuser
-      tag: v5
+      tag: v6
     memory:
       limit: 4G
       guarantee: 1G


### PR DESCRIPTION
Fixes #21 

This upgrades the base image of the users' container. Brings in R 3.4,
new notebook interface, and more. Added textblob and emoji python
packages.

This has been deployed to OHJH.