### PR TITLE
Run nbgitpuller when the container starts

### DIFF
--- a/images/user/Dockerfile
+++ b/images/user/Dockerfile
@@ -5,11 +5,18 @@ FROM jupyter/datascience-notebook:8a1b90cbcba5
 ARG JUPYTERHUB_VERSION=0.8.1
 RUN pip install --no-cache jupyterhub==$JUPYTERHUB_VERSION
 
+
+# Infrastructure extensions and tools
 RUN pip install --no-cache git+https://github.com/OpenHumans/jhoauth-refresh@3ce0b6f7d42f0416cf056dcb887cfefb62b8b513
 RUN jupyter serverextension enable --py jhoauthrefresh --sys-prefix
 
+RUN pip install --no-cache git+https://github.com/data-8/nbgitpuller@28fe9b1af2ba64b346d59bd13c99581346bf349f
+RUN jupyter serverextension enable --py nbgitpuller --sys-prefix
+
+# R packages users like to use
 RUN R -e "install.packages(c('stringr', 'tidytext', 'purrr', 'widyr'), repos = 'http://cran.us.r-project.org')"
 
+# Python packages users like to use
 RUN pip install --no-cache \
        textblob==0.15.1 \
        emoji==0.5.0

--- a/ohjh/values.yaml
+++ b/ohjh/values.yaml
@@ -56,9 +56,13 @@ jupyterhub:
         login_service: "OpenHumans"
 
   singleuser:
+    lifecycleHooks:
+      postStart:
+        exec:
+          command: ["gitpuller", "https://github.com/OpenHumans/ohjh-example-notebooks", "master", "examples"]
     image:
       name: betatim/openhumans-singleuser
-      tag: v6
+      tag: v7
     memory:
       limit: 4G
       guarantee: 1G


### PR DESCRIPTION
This populates the examples/ directory in a users home with the example
notebooks from https://github.com/OpenHumans/ohjh-example-notebooks

This has been deployed. If you login and start your notebook server you should now have a sub directory called `examples/`.