### PR TITLE
Upgrade to newer JHub helm chart

### DIFF
--- a/images/hub/Dockerfile
+++ b/images/hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -10,7 +10,6 @@ RUN apt-get update && \
       libcurl4-openssl-dev \
       libssl-dev \
       build-essential \
-      npm \
       && \
     apt-get purge && apt-get clean
 
@@ -27,12 +26,14 @@ RUN adduser --disabled-password \
     --force-badname \
     ${NB_USER}
 
-ARG JUPYTERHUB_VERSION=0.8.*
+ARG JUPYTERHUB_VERSION=0.9.*
 
 ADD requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir \
-         https://github.com/jupyterhub/jupyterhub/archive/b26b1bc038029fe6ff790b195591ca48250fdd15.zip#egg=jupyterhub
-RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
+         jupyterhub==${JUPYTERHUB_VERSION} \
+         -r /tmp/requirements.txt
+
+RUN pip3 install --no-cache-dir -U https://github.com/jupyterhub/oauthenticator/archive/fce07d4359583e1726c66621e15029785968b1fd.tar.gz
 
 ADD jupyterhub_config.py /srv/jupyterhub_config.py
 

--- a/images/hub/README.md
+++ b/images/hub/README.md
@@ -10,10 +10,10 @@ use it.
 
 The image is based on https://github.com/jupyterhub/zero-to-jupyterhub-k8s/tree/master/images/hub.
 That image is the official image used in the Zero2JupyterHub guide. We make
-our own because we want to add a service to the image and because we want to
-deploy a version of JupyterHub which has not yet been released.
+our own because we want to use a modified version of oauthenticator which has
+not yet been released.
 
-Once there is a release of v0.9 (~April 2019) we should switch to the standard
+Once there is a release we should switch to the standard
 image, or inherit from it.
 
 

--- a/images/hub/cull_idle_servers.py
+++ b/images/hub/cull_idle_servers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Imported from https://github.com/jupyterhub/jupyterhub/blob/0.8.0rc1/examples/cull-idle/cull_idle_servers.py
+# Imported from https://github.com/jupyterhub/jupyterhub/blob/6b1046697/examples/cull-idle/cull_idle_servers.py
 """script to monitor and cull idle single-user servers
 
 Caveats:
@@ -27,7 +27,8 @@ Or run it manually by generating an API token and storing it in `JUPYTERHUB_API_
     python cull_idle_servers.py [--timeout=900] [--url=http://127.0.0.1:8081/hub/api]
 """
 
-import datetime
+from datetime import datetime, timezone
+from functools import partial
 import json
 import os
 
@@ -36,96 +37,274 @@ try:
 except ImportError:
     from urllib import quote
 
-from dateutil.parser import parse as parse_date
+import dateutil.parser
 
-from tornado.gen import coroutine
+from tornado.gen import coroutine, multi
+from tornado.locks import Semaphore
 from tornado.log import app_log
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 from tornado.ioloop import IOLoop, PeriodicCallback
 from tornado.options import define, options, parse_command_line
 
 
+def parse_date(date_string):
+    """Parse a timestamp
+
+    If it doesn't have a timezone, assume utc
+
+    Returned datetime object will always be timezone-aware
+    """
+    dt = dateutil.parser.parse(date_string)
+    if not dt.tzinfo:
+        # assume naïve timestamps are UTC
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def format_td(td):
+    """
+    Nicely format a timedelta object
+
+    as HH:MM:SS
+    """
+    if td is None:
+        return "unknown"
+    if isinstance(td, str):
+        return td
+    seconds = int(td.total_seconds())
+    h = seconds // 3600
+    seconds = seconds % 3600
+    m = seconds // 60
+    seconds = seconds % 60
+    return f"{h:02}:{m:02}:{seconds:02}"
+
+
 @coroutine
-def cull_idle(url, api_token, timeout, cull_users=False):
+def cull_idle(url, api_token, inactive_limit, cull_users=False, max_age=0, concurrency=10):
     """Shutdown idle single-user servers
 
     If cull_users, inactive *users* will be deleted as well.
     """
     auth_header = {
-            'Authorization': 'token %s' % api_token
-        }
-    req = HTTPRequest(url=url + '/users',
+        'Authorization': 'token %s' % api_token,
+    }
+    req = HTTPRequest(
+        url=url + '/users',
         headers=auth_header,
     )
-    now = datetime.datetime.utcnow()
-    cull_limit = now - datetime.timedelta(seconds=timeout)
+    now = datetime.now(timezone.utc)
     client = AsyncHTTPClient()
-    resp = yield client.fetch(req)
+
+    if concurrency:
+        semaphore = Semaphore(concurrency)
+        @coroutine
+        def fetch(req):
+            """client.fetch wrapped in a semaphore to limit concurrency"""
+            yield semaphore.acquire()
+            try:
+                return (yield client.fetch(req))
+            finally:
+                yield semaphore.release()
+    else:
+        fetch = client.fetch
+
+    resp = yield fetch(req)
     users = json.loads(resp.body.decode('utf8', 'replace'))
     futures = []
 
     @coroutine
-    def cull_one(user, last_activity):
-        """cull one user"""
+    def handle_server(user, server_name, server):
+        """Handle (maybe) culling a single server
 
-        # shutdown server first. Hub doesn't allow deleting users with running servers.
-        if user['server']:
-            app_log.info("Culling server for %s (inactive since %s)", user['name'], last_activity)
-            req = HTTPRequest(url=url + '/users/%s/server' % quote(user['name']),
-                method='DELETE',
-                headers=auth_header,
+        Returns True if server is now stopped (user removable),
+        False otherwise.
+        """
+        log_name = user['name']
+        if server_name:
+            log_name = '%s/%s' % (user['name'], server_name)
+        if server.get('pending'):
+            app_log.warning(
+                "Not culling server %s with pending %s",
+                log_name, server['pending'])
+            return False
+
+        if server.get('started'):
+            age = now - parse_date(server['started'])
+        else:
+            # started may be undefined on jupyterhub < 0.9
+            age = None
+
+        # check last activity
+        # last_activity can be None in 0.9
+        if server['last_activity']:
+            inactive = now - parse_date(server['last_activity'])
+        else:
+            # no activity yet, use start date
+            # last_activity may be None with jupyterhub 0.9,
+            # which introduces the 'started' field which is never None
+            # for running servers
+            inactive = age
+
+        should_cull = (inactive is not None and
+                       inactive.total_seconds() >= inactive_limit)
+        if should_cull:
+            app_log.info(
+                "Culling server %s (inactive for %s)",
+                log_name, format_td(inactive))
+
+        if max_age and not should_cull:
+            # only check started if max_age is specified
+            # so that we can still be compatible with jupyterhub 0.8
+            # which doesn't define the 'started' field
+            if age is not None and age.total_seconds() >= max_age:
+                app_log.info(
+                    "Culling server %s (age: %s, inactive for %s)",
+                    log_name, format_td(age), format_td(inactive))
+                should_cull = True
+
+        if not should_cull:
+            app_log.debug(
+                "Not culling server %s (age: %s, inactive for %s)",
+                log_name, format_td(age), format_td(inactive))
+            return False
+
+        req = HTTPRequest(
+            url=url + '/users/%s/server' % quote(user['name']),
+            method='DELETE',
+            headers=auth_header,
+        )
+        resp = yield fetch(req)
+        if resp.code == 202:
+            app_log.warning(
+                "Server %s is slow to stop",
+                log_name,
             )
-            resp = yield client.fetch(req)
-            if resp.code == 202:
-                msg = "Server for {} is slow to stop.".format(user['name'])
-                if cull_users:
-                    app_log.warning(msg + " Not culling user yet.")
-                    # return here so we don't continue to cull the user
-                    # which will fail if the server is still trying to shutdown
-                    return
-                app_log.warning(msg)
-        if cull_users:
-            app_log.info("Culling user %s (inactive since %s)", user['name'], last_activity)
-            req = HTTPRequest(url=url + '/users/%s' % user['name'],
-                method='DELETE',
-                headers=auth_header,
-            )
-            yield client.fetch(req)
+            # return False to prevent culling user with pending shutdowns
+            return False
+        return True
+
+    @coroutine
+    def handle_user(user):
+        """Handle one user.
+
+        Create a list of their servers, and async exec them.  Wait for
+        that to be done, and if all servers are stopped, possibly cull
+        the user.
+        """
+        # shutdown servers first.
+        # Hub doesn't allow deleting users with running servers.
+        # named servers contain the 'servers' dict
+        if 'servers' in user:
+            servers = user['servers']
+        # Otherwise, server data is intermingled in with the user
+        # model
+        else:
+            servers = {}
+            if user['server']:
+                servers[''] = {
+                    'started': user.get('started'),
+                    'last_activity': user['last_activity'],
+                    'pending': user['pending'],
+                    'url': user['server'],
+                }
+        server_futures = [
+            handle_server(user, server_name, server)
+            for server_name, server in servers.items()
+        ]
+        results = yield multi(server_futures)
+        if not cull_users:
+            return
+        # some servers are still running, cannot cull users
+        still_alive = len(results) - sum(results)
+        if still_alive:
+            app_log.debug(
+                "Not culling user %s with %i servers still alive",
+                user['name'], still_alive)
+            return False
+
+        should_cull = False
+        if user.get('created'):
+            age = now - parse_date(user['created'])
+        else:
+            # created may be undefined on jupyterhub < 0.9
+            age = None
+
+        # check last activity
+        # last_activity can be None in 0.9
+        if user['last_activity']:
+            inactive = now - parse_date(user['last_activity'])
+        else:
+            # no activity yet, use start date
+            # last_activity may be None with jupyterhub 0.9,
+            # which introduces the 'created' field which is never None
+            inactive = age
+
+        should_cull = (inactive is not None and
+                       inactive.total_seconds() >= inactive_limit)
+        if should_cull:
+            app_log.info(
+                "Culling user %s (inactive for %s)",
+                user['name'], inactive)
+
+        if max_age and not should_cull:
+            # only check created if max_age is specified
+            # so that we can still be compatible with jupyterhub 0.8
+            # which doesn't define the 'started' field
+            if age is not None and age.total_seconds() >= max_age:
+                app_log.info(
+                    "Culling user %s (age: %s, inactive for %s)",
+                    user['name'], format_td(age), format_td(inactive))
+                should_cull = True
+
+        if not should_cull:
+            app_log.debug(
+                "Not culling user %s (created: %s, last active: %s)",
+                user['name'], format_td(age), format_td(inactive))
+            return False
+
+        req = HTTPRequest(
+            url=url + '/users/%s' % user['name'],
+            method='DELETE',
+            headers=auth_header,
+        )
+        yield fetch(req)
+        return True
 
     for user in users:
-        if not user['server'] and not cull_users:
-            # server not running and not culling users, nothing to do
-            continue
-        if not user['last_activity']:
-            continue
-        last_activity = parse_date(user['last_activity'])
-        if last_activity < cull_limit:
-            # user might be in a transition (e.g. starting or stopping)
-            # don't try to cull if this is happening
-            if user['pending']:
-                app_log.warning("Not culling user %s with pending %s", user['name'], user['pending'])
-                continue
-            futures.append((user['name'], cull_one(user, last_activity)))
-        else:
-            app_log.debug("Not culling %s (active since %s)", user['name'], last_activity)
+        futures.append((user['name'], handle_user(user)))
 
     for (name, f) in futures:
         try:
-            yield f
+            result = yield f
         except Exception:
-            app_log.exception("Error culling %s", name)
+            app_log.exception("Error processing %s", name)
         else:
-            app_log.debug("Finished culling %s", name)
+            if result:
+                app_log.debug("Finished culling %s", name)
 
 
 if __name__ == '__main__':
-    define('url', default=os.environ.get('JUPYTERHUB_API_URL'), help="The JupyterHub API URL")
-    define('timeout', default=600, help="The idle timeout (in seconds)")
-    define('cull_every', default=0, help="The interval (in seconds) for checking for idle servers to cull")
-    define('cull_users', default=False,
-        help="""Cull users in addition to servers.
-                This is for use in temporary-user cases such as tmpnb.""",
+    define(
+        'url',
+        default=os.environ.get('JUPYTERHUB_API_URL'),
+        help="The JupyterHub API URL",
     )
+    define('timeout', default=600, help="The idle timeout (in seconds)")
+    define('cull_every', default=0,
+           help="The interval (in seconds) for checking for idle servers to cull")
+    define('max_age', default=0,
+           help="The maximum age (in seconds) of servers that should be culled even if they are active")
+    define('cull_users', default=False,
+           help="""Cull users in addition to servers.
+                This is for use in temporary-user cases such as tmpnb.""",
+           )
+    define('concurrency', default=10,
+           help="""Limit the number of concurrent requests made to the Hub.
+
+                Deleting a lot of users at the same time can slow down the Hub,
+                so limit the number of API requests we have outstanding at any given time.
+                """
+           )
 
     parse_command_line()
     if not options.cull_every:
@@ -135,10 +314,21 @@ if __name__ == '__main__':
     try:
         AsyncHTTPClient.configure("tornado.curl_httpclient.CurlAsyncHTTPClient")
     except ImportError as e:
-        app_log.warning("Could not load pycurl: %s\npycurl is recommended if you have a large number of users.", e)
+        app_log.warning(
+            "Could not load pycurl: %s\n"
+            "pycurl is recommended if you have a large number of users.",
+            e)
 
     loop = IOLoop.current()
-    cull = lambda : cull_idle(options.url, api_token, options.timeout, options.cull_users)
+    cull = partial(
+        cull_idle,
+        url=options.url,
+        api_token=api_token,
+        inactive_limit=options.timeout,
+        cull_users=options.cull_users,
+        max_age=options.max_age,
+        concurrency=options.concurrency,
+    )
     # schedule first cull immediately
     # because PeriodicCallback doesn't start until the end of the first interval
     loop.add_callback(cull)

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -3,7 +3,7 @@ import glob
 from tornado.httpclient import AsyncHTTPClient
 from kubernetes import client
 
-from z2jh import get_config, get_secret
+from z2jh import get_config, get_secret, set_config_if_not_none
 
 # Configure JupyterHub to use the curl backend for making HTTP requests,
 # rather than the pure-python implementations. The default one starts
@@ -28,7 +28,6 @@ c.JupyterHub.last_activity_interval = 60
 c.JupyterHub.concurrent_spawn_limit = get_config('hub.concurrent-spawn-limit')
 
 active_server_limit = get_config('hub.active-server-limit', None)
-
 if active_server_limit is not None:
     c.JupyterHub.active_server_limit = int(active_server_limit)
 
@@ -38,37 +37,41 @@ c.JupyterHub.port = int(os.environ['PROXY_PUBLIC_SERVICE_PORT'])
 # the hub should listen on all interfaces, so the proxy can access it
 c.JupyterHub.hub_ip = '0.0.0.0'
 
+c.KubeSpawner.common_labels = get_config('kubespawner.common-labels')
+
 c.KubeSpawner.namespace = os.environ.get('POD_NAMESPACE', 'default')
 
 c.KubeSpawner.start_timeout = get_config('singleuser.start-timeout')
 
 # Use env var for this, since we want hub to restart when this changes
-c.KubeSpawner.singleuser_image_spec = os.environ['SINGLEUSER_IMAGE']
+c.KubeSpawner.image_spec = os.environ['SINGLEUSER_IMAGE']
 
-c.KubeSpawner.singleuser_image_pull_policy = get_config('singleuser.image-pull-policy')
+c.KubeSpawner.image_pull_policy = get_config('singleuser.image-pull-policy')
 
-c.KubeSpawner.singleuser_extra_labels = get_config('singleuser.extra-labels', {})
+c.KubeSpawner.events_enabled = get_config('singleuser.events', False)
 
-c.KubeSpawner.singleuser_uid = get_config('singleuser.uid')
-c.KubeSpawner.singleuser_fs_gid = get_config('singleuser.fs-gid')
+c.KubeSpawner.extra_labels = get_config('singleuser.extra-labels', {})
+
+c.KubeSpawner.uid = get_config('singleuser.uid')
+c.KubeSpawner.fs_gid = get_config('singleuser.fs-gid')
 
 service_account_name = get_config('singleuser.service-account-name', None)
 if service_account_name:
-    c.KubeSpawner.singleuser_service_account = service_account_name
+    c.KubeSpawner.service_account = service_account_name
 
-c.KubeSpawner.singleuser_node_selector = get_config('singleuser.node-selector')
+c.KubeSpawner.node_selector = get_config('singleuser.node-selector')
 # Configure dynamically provisioning pvc
 storage_type = get_config('singleuser.storage.type')
 if storage_type == 'dynamic':
     pvc_name_template = get_config('singleuser.storage.dynamic.pvc-name-template')
     volume_name_template = get_config('singleuser.storage.dynamic.volume-name-template')
     c.KubeSpawner.pvc_name_template = pvc_name_template
-    c.KubeSpawner.user_storage_pvc_ensure = True
+    c.KubeSpawner.storage_pvc_ensure = True
     storage_class = get_config('singleuser.storage.dynamic.storage-class', None)
     if storage_class:
-        c.KubeSpawner.user_storage_class = storage_class
-    c.KubeSpawner.user_storage_access_modes = get_config('singleuser.storage.dynamic.storage-access-modes')
-    c.KubeSpawner.user_storage_capacity = get_config('singleuser.storage.capacity')
+        c.KubeSpawner.storage_class = storage_class
+    c.KubeSpawner.storage_access_modes = get_config('singleuser.storage.dynamic.storage-access-modes')
+    c.KubeSpawner.storage_capacity = get_config('singleuser.storage.capacity')
 
     # Add volumes to singleuser pods
     c.KubeSpawner.volumes = [
@@ -105,11 +108,11 @@ c.KubeSpawner.volume_mounts.extend(get_config('singleuser.storage.extra-volume-m
 
 lifecycle_hooks = get_config('singleuser.lifecycle-hooks')
 if lifecycle_hooks:
-    c.KubeSpawner.singleuser_lifecycle_hooks = lifecycle_hooks
+    c.KubeSpawner.lifecycle_hooks = lifecycle_hooks
 
 init_containers = get_config('singleuser.init-containers')
 if init_containers:
-    c.KubeSpawner.singleuser_init_containers.extend(init_containers)
+    c.KubeSpawner.init_containers.extend(init_containers)
 
 # Gives spawned containers access to the API of the hub
 c.KubeSpawner.hub_connect_ip = os.environ['HUB_SERVICE_HOST']
@@ -132,7 +135,7 @@ if auth_type == 'google':
     c.GoogleOAuthenticator.client_id = get_config('auth.google.client-id')
     c.GoogleOAuthenticator.client_secret = get_config('auth.google.client-secret')
     c.GoogleOAuthenticator.oauth_callback_url = get_config('auth.google.callback-url')
-    c.GoogleOAuthenticator.hosted_domain = get_config('auth.google.hosted-domain')
+    set_config_if_not_none(c.GoogleOAuthenticator, 'hosted_domain', 'auth.google.hosted-domain')
     c.GoogleOAuthenticator.login_service = get_config('auth.google.login-service')
     email_domain = get_config('auth.google.hosted-domain')
 elif auth_type == 'github':
@@ -175,6 +178,22 @@ elif auth_type == 'tmp':
 elif auth_type == 'lti':
     c.JupyterHub.authenticator_class = 'ltiauthenticator.LTIAuthenticator'
     c.LTIAuthenticator.consumers = get_config('auth.lti.consumers')
+elif auth_type == 'ldap':
+    c.JupyterHub.authenticator_class = 'ldapauthenticator.LDAPAuthenticator'
+    c.LDAPAuthenticator.server_address = get_config('auth.ldap.server.address')
+    set_config_if_not_none(c.LDAPAuthenticator, 'server_port', 'auth.ldap.server.port')
+    set_config_if_not_none(c.LDAPAuthenticator, 'use_ssl', 'auth.ldap.server.ssl')
+    set_config_if_not_none(c.LDAPAuthenticator, 'allowed_groups', 'auth.ldap.allowed-groups')
+    c.LDAPAuthenticator.bind_dn_template = get_config('auth.ldap.dn.templates')
+    set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn', 'auth.ldap.dn.lookup')
+    set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_search_filter', 'auth.ldap.dn.search.filter')
+    set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_search_user', 'auth.ldap.dn.search.user')
+    set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_search_password', 'auth.ldap.dn.search.password')
+    set_config_if_not_none(c.LDAPAuthenticator, 'lookup_dn_user_dn_attribute', 'auth.ldap.dn.user.dn-attribute')
+    set_config_if_not_none(c.LDAPAuthenticator, 'escape_userdn', 'auth.ldap.dn.user.escape')
+    set_config_if_not_none(c.LDAPAuthenticator, 'valid_username_regex', 'auth.ldap.dn.user.valid-regex')
+    set_config_if_not_none(c.LDAPAuthenticator, 'user_search_base', 'auth.ldap.dn.user.search-base')
+    set_config_if_not_none(c.LDAPAuthenticator, 'user_attribute', 'auth.ldap.dn.user.attribute')
 elif auth_type == 'custom':
     # full_class_name looks like "myauthenticator.MyAuthenticator".
     # To create a docker image with this class availabe, you can just have the
@@ -230,14 +249,26 @@ c.JupyterHub.services = []
 if get_config('cull.enabled', False):
     cull_timeout = get_config('cull.timeout')
     cull_every = get_config('cull.every')
+    cull_concurrency = get_config('cull.concurrency')
     cull_cmd = [
         '/usr/local/bin/cull_idle_servers.py',
         '--timeout=%s' % cull_timeout,
         '--cull-every=%s' % cull_every,
-        '--url=http://127.0.0.1:8081' + c.JupyterHub.base_url + 'hub/api'
+        '--concurrency=%s' % cull_concurrency,
+        '--url=http://127.0.0.1:8081' + c.JupyterHub.base_url + 'hub/api',
     ]
+
     if get_config('cull.users'):
         cull_cmd.append('--cull-users')
+
+    # FIXME: remove version check when we require jupyterhub 0.9 in the chart
+    # that will also mean we can remove the podCuller image
+    import jupyterhub
+    from distutils.version import LooseVersion as V
+    cull_max_age = get_config('cull.max-age')
+    if cull_max_age and V(jupyterhub.__version__) >= V('0.9'):
+        cull_cmd.append('--max-age=%s' % cull_max_age)
+
     c.JupyterHub.services.append({
         'name': 'cull-idle',
         'admin': True,
@@ -286,13 +317,13 @@ if not cloud_metadata.get('enabled', False):
         )
     )
 
-    c.KubeSpawner.singleuser_init_containers.append(ip_block_container)
+    c.KubeSpawner.init_containers.append(ip_block_container)
 
 scheduler_strategy = get_config('singleuser.scheduler-strategy', 'spread')
 
 if scheduler_strategy == 'pack':
     # FIXME: Support setting affinity directly in KubeSpawner
-    c.KubeSpawner.singleuser_extra_pod_config = {
+    c.KubeSpawner.extra_pod_config = {
         'affinity': {
             'podAffinity': {
                 'preferredDuringSchedulingIgnoredDuringExecution': [{
@@ -323,9 +354,6 @@ if scheduler_strategy == 'pack':
             }
         }
     }
-else:
-    # Set default to {} so subconfigs can easily update it
-    c.KubeSpawner.singleuser_extra_pod_config = {}
 
 if get_config('debug.enabled', False):
     c.JupyterHub.log_level = 'DEBUG'

--- a/images/hub/requirements.txt
+++ b/images/hub/requirements.txt
@@ -8,6 +8,7 @@ psycopg2==2.7.3.2
 pycurl==7.43.0
 mwoauth==0.3.2
 globus_sdk[jwt]==1.2.1
-https://github.com/jupyterhub/oauthenticator/archive/fce07d4359583e1726c66621e15029785968b1fd.tar.gz
+oauthenticator==0.7.2
 cryptography==2.0.3
-https://github.com/jupyterhub/kubespawner/archive/86386e8.tar.gz
+https://github.com/jupyterhub/kubespawner/archive/7ae9900.tar.gz
+https://github.com/jupyterhub/ldapauthenticator/archive/718eb59.tar.gz

--- a/images/hub/z2jh.py
+++ b/images/hub/z2jh.py
@@ -29,3 +29,12 @@ def get_secret(key, default=None):
             return f.read().strip()
     except FileNotFoundError:
         return default
+
+def set_config_if_not_none(cparent, name, key):
+    """
+    Find a config item of a given name, set the corresponding Jupyter
+    configuration item if not None
+    """
+    data = get_config(key)
+    if data is not None:
+        setattr(cparent, name, data)

--- a/ohjh/requirements.lock
+++ b/ohjh/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: jupyterhub
   repository: https://jupyterhub.github.io/helm-chart
-  version: v0.7-c491965
-digest: sha256:d3e744aa98d793446654fbc7e0ac598e57ffca2f01c074ddd3147c1936fc19a9
-generated: 2018-03-27T12:51:04.848433365+02:00
+  version: v0.7-560a7cd
+digest: sha256:4689c92aa460c9ac2962d598567e2c5e8ec9ceb8ccef1765fa2821f19cf269ce
+generated: 2018-07-24T18:37:41.796665335+02:00

--- a/ohjh/requirements.yaml
+++ b/ohjh/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: jupyterhub
-  version: "v0.7-c491965"
+  version: "v0.7-560a7cd"
   repository: "https://jupyterhub.github.io/helm-chart"

--- a/ohjh/values.yaml
+++ b/ohjh/values.yaml
@@ -19,7 +19,7 @@ jupyterhub:
         url: http://refresher/
     image:
       name: betatim/openhumans-hub
-      tag: v7
+      tag: v10
     extraConfig: |
       from tornado import gen
       from kubespawner.spawner import KubeSpawner
@@ -29,6 +29,7 @@ jupyterhub:
           @gen.coroutine
           def pre_spawn_start(self, user, spawner):
               auth_state = yield user.get_auth_state()
+              self.log.error('auth state %s', auth_state)
               spawner.auth_state = auth_state
 
       class OHKubeSpawner(KubeSpawner):

--- a/ohjh/values.yaml
+++ b/ohjh/values.yaml
@@ -1,5 +1,7 @@
 jupyterhub:
   proxy:
+    pdb:
+      enabled: false
     service:
       loadBalancerIP: 35.224.161.135
     https:
@@ -9,6 +11,8 @@ jupyterhub:
         contactEmail: accounts+letsencrypt@openhumans.org
 
   hub:
+    pdb:
+      enabled: false
     services:
       refresher:
         admin: true


### PR DESCRIPTION
This upgrades the hub to the latest available chart version.

We had a failed deploy because at first the `pdb` (pod disruption budget) was enabled which caused a failed deploy.

After fixing that in `values.yaml` `helm upgrade ...` failed with an error like `Error: UPGRADE FAILED: no ServiceAccount with the name "autohttps" found`. This was probably because the failed deploy left things in a "weird" state. The solution was to `helm rollback ohjh 79` where 79 was the revision before the upgrade. After that `helm upgrade ...` succeeded.

We ended up with a crashing hub pod though because the proxy rolebinding(?) did not have the right permissions to list all the ingresses.

We solved that by deleting the deployment and installing from scratch.