### PR TITLE
Update kube-lego version to fix non-renewal bug

### DIFF
--- a/ohjh/values.yaml
+++ b/ohjh/values.yaml
@@ -1,5 +1,10 @@
 jupyterhub:
   proxy:
+    # manually override kube-lego version until the JupyterHub Chart
+    # also uses this version. Fixes non-renewal of certificates
+    lego:
+      image:
+        tag: 0.1.7
     pdb:
       enabled: false
     service:


### PR DESCRIPTION
Version 0.1.6 of kube-lego does not renew certificates before they
expire, this bug was fixed in 0.1.7 so updating to that version.

More details/discussion in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/963