### PR TITLE
Bring back voila by removing the proxy

### DIFF
--- a/images/user/Dockerfile
+++ b/images/user/Dockerfile
@@ -34,10 +34,6 @@ RUN pip install --no-cache --upgrade \
 
 RUN python -m textblob.download_corpora
 
-RUN echo "\nc.ServerProxy.servers = {" >> /etc/jupyter/jupyter_notebook_config.py
-RUN echo "'voila': {" >> /etc/jupyter/jupyter_notebook_config.py
-RUN echo "'command': ['voila', '--port', '{port}', '--server_url', '/', '--base_url', '{base_url}/voila/']}}" >> /etc/jupyter/jupyter_notebook_config.py
-
 
 # R packages users like to use
 RUN R -e "install.packages(c('stringr', 'tidytext', 'purrr', 'widyr'), repos = 'http://cran.us.r-project.org')"

--- a/ohjh/values.yaml
+++ b/ohjh/values.yaml
@@ -67,7 +67,7 @@ jupyterhub:
           command: ["gitpuller", "https://github.com/OpenHumans/ohjh-example-notebooks", "master", "examples"]
     image:
       name: "betatim/openhumans-singleuser"
-      tag: "v10"
+      tag: "v12"
     memory:
       limit: 4G
       guarantee: 1G


### PR DESCRIPTION
jupyter-server-proxy is not needed anymore to use voila on a jupyterhub.